### PR TITLE
Add module docstrings for backend files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,16 @@
 # backend/main.py
+"""FastAPI server that connects the frontend with LLMs and MCP tools.
+
+Endpoints:
+    * ``/api/tools`` -- list tools discovered from MCP servers
+    * ``/api/echo``  -- route a user message through an LLM and optional tools
+
+Key helpers:
+    ``llm_router`` routes text to OpenAI,
+    ``get_mcp_tools`` caches tool discovery,
+    ``find_relevant_tool`` picks a tool based on simple keywords.
+"""
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -1,7 +1,14 @@
 # backend/mcp_client.py
-"""
-Async-only MCP client for discovering tools and executing tool calls.
-All stub/mock (non-async) code has been removed.
+"""Async client for interacting with Modular Command Protocol (MCP) servers.
+
+Core functions include:
+    ``list_mcp_servers``  -- read configured server URLs
+    ``discover_tools``    -- query a single server for its tools
+    ``get_tool_schema``   -- fetch a tool's JSON schema
+    ``execute_tool``      -- run a tool with parameter validation
+    ``discover_all_tools``-- gather tools from all servers
+
+All networking is performed with ``httpx`` using asyncio.
 """
 
 import os


### PR DESCRIPTION
## Summary
- document backend modules

## Testing
- `python -m py_compile backend/main.py backend/mcp_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ed095ce0832d9e7198ac9bb7f9e5