### PR TITLE
Remove unused MCP_SERVER_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ cp .env.example .env
 # Edit .env with your API keys
 ```
 
+### Environment Variables
+The `.env` file controls API keys and MCP tool settings. Important variables:
+
+- `OPENAI_API_KEY` – OpenAI authentication (optional)
+- `MCP_SERVER_URLS` – comma-separated list of MCP server endpoints
+- `MCP_DISCOVERY_TIMEOUT` – tool discovery timeout (seconds)
+- `MCP_EXECUTION_TIMEOUT` – tool execution timeout (seconds)
+
 ### 2. Launch with Docker (Recommended)
 ```bash
 docker compose up --build

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,6 @@ OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 OPENAI_MODEL = os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
 CLAUDE_API_KEY = os.getenv('CLAUDE_API_KEY')
 OLLAMA_ENDPOINT = os.getenv('OLLAMA_ENDPOINT')
-MCP_SERVER_URL = os.getenv('MCP_SERVER_URL')
 
 openai.api_key = OPENAI_API_KEY
 


### PR DESCRIPTION
## Summary
- drop unused `MCP_SERVER_URL` variable from backend
- document `MCP_SERVER_URLS` and other `.env` settings in README

## Testing
- `python -m py_compile backend/main.py backend/mcp_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6852ece3a440832d942c43bbfe56d80e