### PR TITLE
Add backend API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ cd Echo
 - **Docker:** Lightweight, production-ready config. Mounts code for live reload.
 - **Extending:** Add new LLMs/tools by editing `llm_router.py` and `mcp_client.py`.
 
+### Running Tests
+Echo includes a small pytest suite under `tests/`.
+
+```bash
+pip install -r backend/requirements.txt
+pip install pytest respx
+pytest
+```
+
 ---
 
 ## Roadmap

--- a/tests/test_api_echo.py
+++ b/tests/test_api_echo.py
@@ -1,0 +1,66 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from fastapi.testclient import TestClient
+from backend import main
+
+def test_echo_with_tool_execution(monkeypatch):
+    async def mock_get_mcp_tools(force_refresh=False):
+        return {
+            "http://mockserver": [
+                {"name": "calculator", "parameters": {"expression": {"type": "string"}}}
+            ]
+        }
+
+    def mock_find_relevant_tool(message, tools):
+        return "http://mockserver", "calculator", {"parameters": {"expression": {"type": "string"}}}
+
+    async def mock_execute_tool(server, tool, params):
+        return {"result": "42"}
+
+    def mock_llm_router(message):
+        return f"LLM:{message}"
+
+    main.MCP_TOOLS_CACHE = {}
+    main.MCP_TOOLS_LAST_REFRESH = 0
+    monkeypatch.setattr(main, "get_mcp_tools", mock_get_mcp_tools)
+    monkeypatch.setattr(main, "find_relevant_tool", mock_find_relevant_tool)
+    monkeypatch.setattr(main, "execute_tool", mock_execute_tool)
+    monkeypatch.setattr(main, "llm_router", mock_llm_router)
+
+    client = TestClient(main.app)
+    resp = client.post("/api/echo", json={"message": "calculate 2+2"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tools_used"][0]["name"] == "calculator"
+    assert data["tools_used"][0]["result"] == "42"
+    assert data["response"].startswith("LLM:")
+
+def test_echo_tool_error(monkeypatch):
+    async def mock_get_mcp_tools(force_refresh=False):
+        return {"http://mockserver": [{"name": "calculator", "parameters": {"expression": {"type": "string"}}}]}
+
+    def mock_find_relevant_tool(message, tools):
+        return "http://mockserver", "calculator", {"parameters": {"expression": {"type": "string"}}}
+
+    async def mock_execute_tool(server, tool, params):
+        raise main.MCPClientError("bad params")
+
+    captured = {}
+    def mock_llm_router(message):
+        captured["msg"] = message
+        return "LLM error"
+
+    main.MCP_TOOLS_CACHE = {}
+    main.MCP_TOOLS_LAST_REFRESH = 0
+    monkeypatch.setattr(main, "get_mcp_tools", mock_get_mcp_tools)
+    monkeypatch.setattr(main, "find_relevant_tool", mock_find_relevant_tool)
+    monkeypatch.setattr(main, "execute_tool", mock_execute_tool)
+    monkeypatch.setattr(main, "llm_router", mock_llm_router)
+
+    client = TestClient(main.app)
+    resp = client.post("/api/echo", json={"message": "calculate 2+2"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tools_used"] == []
+    assert "bad params" in captured["msg"]

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -1,0 +1,32 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from fastapi.testclient import TestClient
+from backend import main
+
+def test_tools_endpoint_structure(monkeypatch):
+    async def mock_discover_all_tools():
+        return {
+            "http://mockserver": [
+                {"name": "calculator", "description": "Adds numbers", "parameters": {"expression": {"type": "string"}}}
+            ]
+        }
+
+    # Clear cache and patch discovery
+    main.MCP_TOOLS_CACHE = {}
+    main.MCP_TOOLS_LAST_REFRESH = 0
+    monkeypatch.setattr(main, "discover_all_tools", mock_discover_all_tools)
+
+    client = TestClient(main.app)
+    resp = client.get("/api/tools")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "tools": [
+            {
+                "name": "calculator",
+                "description": "Adds numbers",
+                "server_url": "http://mockserver"
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- add pytest suite for `/api/tools` and `/api/echo`
- document test execution in the README

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest respx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ed05ac4c832d80dc1fcc51e5d4f5