### PR TITLE
Add sample MCP server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ cd Echo
 - `GET /docs` – FastAPI interactive API docs
 - `GET /` – Not implemented (returns 404 by design)
 
+### Sample MCP Server for Local Testing
+See [docs/sample_mcp_server.md](docs/sample_mcp_server.md) for a minimal example server you can run locally.
+
 ---
 
 ## Development Notes

--- a/docs/sample_mcp_server.md
+++ b/docs/sample_mcp_server.md
@@ -1,0 +1,37 @@
+# Sample MCP Server
+
+This repository does not include a full MCP implementation, but you can run a minimal server locally for testing Echo's tool integration.
+
+## Quick Start
+
+1. **Install dependencies**
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. **Run the example server**
+   ```bash
+   python sample_mcp_server.py
+   ```
+   The server listens on `http://localhost:8001`.
+
+## Tool Schema and Endpoints
+
+The sample server exposes a single `calculator` tool with the following schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "expression": { "type": "string" }
+  },
+  "required": ["expression"]
+}
+```
+
+Available endpoints:
+
+- `GET /tools` – list available tools.
+- `GET /tools/{tool}/schema` – return JSON schema for parameters.
+- `POST /tools/{tool}/execute` – execute the tool and return `{ "result": ... }`.
+
+Set `MCP_SERVER_URLS=http://localhost:8001` in your `.env` so the Echo backend can discover this tool.

--- a/sample_mcp_server.py
+++ b/sample_mcp_server.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+app = FastAPI(title="Sample MCP Server")
+
+# List of available tools
+@app.get("/tools")
+async def list_tools():
+    return [{
+        "name": "calculator",
+        "description": "Evaluate simple math expressions",
+        "parameters": {"expression": "string"}
+    }]
+
+# JSON schema for tool parameters
+@app.get("/tools/{tool_name}/schema")
+async def tool_schema(tool_name: str):
+    if tool_name != "calculator":
+        return {"error": "unknown tool"}
+    return {
+        "type": "object",
+        "properties": {
+            "expression": {"type": "string"}
+        },
+        "required": ["expression"]
+    }
+
+class Expr(BaseModel):
+    expression: str
+
+# Execute tool
+@app.post("/tools/{tool_name}/execute")
+async def execute(tool_name: str, payload: Expr):
+    if tool_name != "calculator":
+        return {"error": "unknown tool"}
+    try:
+        result = eval(payload.expression, {"__builtins__": {}})
+    except Exception as e:
+        return {"error": str(e)}
+    return {"result": result}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8001)


### PR DESCRIPTION
## Summary
- document how to run a minimal MCP server for testing
- link new documentation from README
- provide `sample_mcp_server.py` example implementation

## Testing
- `python -m py_compile sample_mcp_server.py`
- `python -m py_compile backend/main.py backend/mcp_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6852ed0729c0832d8eeeae0e6a2aa7d8